### PR TITLE
Show truncated description if there is no company summary

### DIFF
--- a/company/templates/company-profile-detail.html
+++ b/company/templates/company-profile-detail.html
@@ -64,7 +64,11 @@
 					</p>
 				{% else %}
 					<p>
-						{{ company.summary }}
+						{% if company.summary %}
+							{{ company.summary }}
+						{% elif company.description %}
+							{{ company.description|truncatechars:200 }}
+						{% endif %}
 						{# reload current page with querystring #}
 						<a href="?verbose=true">Read full company profile</a>
 					</p>

--- a/company/tests/test_templates.py
+++ b/company/tests/test_templates.py
@@ -190,3 +190,27 @@ def test_public_profile_non_verbose():
     assert 'href="?verbose=true"' in html
     assert context['company']['summary'] in html
     assert context['company']['description'] not in html
+
+
+def test_public_profile_non_verbose_missing_summary():
+    description = (
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed doesel '
+        'eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enime'
+        ' ad minim veniam, quis nostrud exercitation ullamco laboris nisileds'
+    )
+    expected = description[0:197] + '...'
+    # sanity testing the values for the test. The description should be
+    # truncated to 200 chars, including the ellipsis chars.
+    assert len(description) == 204
+    assert len(expected) == 200
+
+    context = {
+        'show_description': False,
+        'company': {
+            'summary': '',
+            'description': description
+        }
+    }
+    html = render_to_string('company-profile-detail.html', context)
+
+    assert expected in html


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-725)

# non-verbose, with summary set
![image](https://cloud.githubusercontent.com/assets/5485798/21966639/e35f9bb2-db6e-11e6-94e9-6bdeddc96a97.png)


# non-verbose, with summary not set
![image](https://cloud.githubusercontent.com/assets/5485798/21966635/d3d6cea4-db6e-11e6-9c0e-8d5ed8dbbdf8.png)

# verbose
![image](https://cloud.githubusercontent.com/assets/5485798/21966637/dc780938-db6e-11e6-86dc-5f189fc01504.png)

