### PR TITLE
Remove unwanted capitalisation from industries in FAS search

### DIFF
--- a/core/helpers.py
+++ b/core/helpers.py
@@ -93,20 +93,25 @@ def get_results_from_search_response(response):
 
 
 def get_filters_labels(filters):
+    sectors = dict(choices.INDUSTRIES)
+    languages = dict(choices.EXPERTISE_LANGUAGES)
     labels = []
+    skip_fields = [
+        'q',
+        'page',
+        # Prevents duplicates labels not to be displayed in filter list
+        'expertise_products_services_label'
+    ]
     for name, values in filters.items():
-        if name not in ['q', 'page']:
-            if name == 'expertise_languages':
-                languages = dict(choices.EXPERTISE_LANGUAGES)
-                labels += [
-                    languages[item] for item in values if item in languages
-                ]
-            # Prevents duplicates labels not to be displayed in filter list
-            elif name.startswith('expertise_products_services_label'):
-                pass
-            elif name.startswith('expertise_products_services_'):
-                labels += values
-            else:
-                for value in values:
-                    labels.append(value.replace('_', ' ').title())
+        if name in skip_fields:
+            pass
+        elif name == 'industries':
+            labels += [sectors[item] for item in values if item in sectors]
+        elif name == 'expertise_languages':
+            labels += [languages[item] for item in values if item in languages]
+        elif name.startswith('expertise_products_services_'):
+            labels += values
+        else:
+            for value in values:
+                labels.append(value.replace('_', ' ').title())
     return labels

--- a/core/tests/test_helpers.py
+++ b/core/tests/test_helpers.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 
-from directory_constants import expertise
+from directory_constants import expertise, sectors
 
 from django.shortcuts import Http404
 from django.urls import reverse
@@ -132,13 +132,16 @@ def test_get_filters_labels():
         'q': 'foo',
         'page': 5,
         'expertise_regions': ['NORTH_EAST'],
-        'expertise_products_services_financial': [expertise.FINANCIAL[1]]
+        'expertise_products_services_financial': [expertise.FINANCIAL[1]],
+        'industries': [sectors.AEROSPACE, sectors.ADVANCED_MANUFACTURING]
     }
 
     expected = [
         'Afar',
         'North East',
         'Insurance',
+        'Aerospace',
+        'Advanced manufacturing',
     ]
 
     assert helpers.get_filters_labels(filters) == expected


### PR DESCRIPTION
To do:

 - [x] feature has a jira ticket that has correct status
 - [x] changelog entry added
 - [x] Add a printscreen to the PR

![image](https://user-images.githubusercontent.com/5485798/60020249-8d7c5d80-9687-11e9-9c0c-0788cd0a3501.png)
