### PR TITLE
Keep FAS industry filter open by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pre release
 
+### Implemented enhancements
+- TT-1596 - Keep FAS industry filter open by default
+
 ## [2019.06.25] (https://github.com/uktrade/directory-ui-supplier/releases/tag/2019.06.25)
 [Full Changelog](https://github.com/uktrade/directory-ui-supplier/compare/2019.06.05...2019.06.25)
 

--- a/core/templates/core/filter.html
+++ b/core/templates/core/filter.html
@@ -1,6 +1,6 @@
 <div>
     <label for="toggle_id_{{ field.name }}">{{ label }}</label>
-    <button type="button" id="toggle_id_{{ field.name }}" aria-controls="id_{{ field.name }}-container" class="filter-collapse checked" alt="{{ alt }}"></button>
+    <button type="button" id="toggle_id_{{ field.name }}" aria-controls="id_{{ field.name }}-container" class="filter-collapse {{ open|yesno:',checked' }}" alt="{{ alt }}"></button>
     <div class="{{ field.css_classes }}" id="id_{{ field.name }}-container" aria-expanded="false">
         {{field}}
     </div>

--- a/find_a_supplier/templates/find_a_supplier/search.html
+++ b/find_a_supplier/templates/find_a_supplier/search.html
@@ -14,7 +14,7 @@
 {% block filters %}
     <fieldset>
         <legend>Filter by industry</legend>
-        {% include 'core/filter.html' with label='Industry' alt='Toggle list of industries' field=form.industries %}
+        {% include 'core/filter.html' with label='Industry' alt='Toggle list of industries' field=form.industries open=True %}
     </fieldset>
     <fieldset>
 {% endblock %}


### PR DESCRIPTION
To do:

 - [x] feature has a jira ticket that has correct status
 - [x] changelog entry added
 - [x] it's accessible to the standards we subscribe to
 - [x] Add a printscreen to the PR

![image](https://user-images.githubusercontent.com/5485798/60280237-74c7ae00-98fa-11e9-9bff-bd3826b6efb8.png)
![image](https://user-images.githubusercontent.com/5485798/60280245-78f3cb80-98fa-11e9-91e0-f850101bb280.png)
