### PR TITLE
Fix duplicate filter listings in search

### DIFF
--- a/core/helpers.py
+++ b/core/helpers.py
@@ -100,7 +100,7 @@ def get_filters_labels(filters):
         'q',
         'page',
         # Prevents duplicates labels not to be displayed in filter list
-        'expertise_products_services_label'
+        'expertise_products_services_labels',
     ]
     for name, values in filters.items():
         if name in skip_fields:

--- a/core/tests/test_helpers.py
+++ b/core/tests/test_helpers.py
@@ -133,7 +133,10 @@ def test_get_filters_labels():
         'page': 5,
         'expertise_regions': ['NORTH_EAST'],
         'expertise_products_services_financial': [expertise.FINANCIAL[1]],
-        'industries': [sectors.AEROSPACE, sectors.ADVANCED_MANUFACTURING]
+        'industries': [sectors.AEROSPACE, sectors.ADVANCED_MANUFACTURING],
+        'expertise_products_services_human_resources': [
+            'Employment and talent research'
+        ],
     }
 
     expected = [
@@ -142,6 +145,7 @@ def test_get_filters_labels():
         'Insurance',
         'Aerospace',
         'Advanced manufacturing',
+        'Employment and talent research',
     ]
 
     assert helpers.get_filters_labels(filters) == expected


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] Add a printscreen to the PR

![image](https://user-images.githubusercontent.com/5485798/60452412-575e5100-9c26-11e9-8aa6-91d10e672b36.png)
