### PR TITLE
Tt 1676 add back link to search results on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pre release
 
+- TT-1556 - Newsletter form on FAS search results page
+    + TT-1676 - FAS Add Back link to subscription success page to show previous search results instead of empty search.
 - TT-1623 - Change logo on ISD pages to invest logo
 - TT-1556 - Add captcha to subscribe form
 

--- a/find_a_supplier/templates/find_a_supplier/search.html
+++ b/find_a_supplier/templates/find_a_supplier/search.html
@@ -33,7 +33,7 @@
                 </div>
                 <div class="grid-row">
                     {% ga360_tracker "subscribe-form" target="form" %}
-                    <form action="{% url 'subscribe' %}" method="post">
+                    <form action="{% url 'subscribe' %}{% if search_querystring %}?{{ search_querystring }}{% endif %}" method="post">
                         <div class="grid-row">
                             <div class="column-full column-third-xl">
                                 {% include "directory_components/form_widgets/form_field.html" with field=subscribe_form.full_name %}

--- a/find_a_supplier/templates/find_a_supplier/subscribe-success.html
+++ b/find_a_supplier/templates/find_a_supplier/subscribe-success.html
@@ -24,7 +24,7 @@
       <div class="container">
         <h2 class="heading-large">Next steps</h2>
         {% ga360_tracker "next-steps" %}
-        <a class="link" href="{% url 'find-a-supplier:search' %}">Browse companies</a>
+        <a class="link" href="{% url 'find-a-supplier:search' %}{% if search_querystring %}?{{ search_querystring }}{% endif %}">Browse companies</a>
         {% endga360_tracker %}
       </div>
     </section>

--- a/find_a_supplier/templates/find_a_supplier/subscribe.html
+++ b/find_a_supplier/templates/find_a_supplier/subscribe.html
@@ -23,7 +23,7 @@
             </div>
             <div class="grid-row">
                 {% ga360_tracker "subscribe-form" target="form" %}
-                <form action="{% url 'subscribe' %}" method="post" class="column-full column-half-xl">
+                <form action="{% url 'subscribe' %}{% if search_querystring %}?{{ search_querystring }}{% endif %}" method="post" class="column-full column-half-xl">
                     {% render_form form %}
                     <button class="button">Send</button>
                 </form>

--- a/find_a_supplier/views.py
+++ b/find_a_supplier/views.py
@@ -294,7 +294,12 @@ class ContactCompanySentView(
         )
 
 
-class SubscribeFormView(CountryDisplayMixin, GA360Mixin, FormView):
+class SubscribeFormView(
+    CountryDisplayMixin,
+    GA360Mixin,
+    core.mixins.PersistSearchQuerystringMixin,
+    FormView
+):
     success_template = 'find_a_supplier/subscribe-success.html'
     template_name = 'find_a_supplier/subscribe.html'
     form_class = forms.AnonymousSubscribeForm
@@ -318,3 +323,4 @@ class SubscribeFormView(CountryDisplayMixin, GA360Mixin, FormView):
             self.success_template,
             self.get_context_data()
         )
+

--- a/find_a_supplier/views.py
+++ b/find_a_supplier/views.py
@@ -323,4 +323,3 @@ class SubscribeFormView(
             self.success_template,
             self.get_context_data()
         )
-


### PR DESCRIPTION
 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [x] (if changing the UI) Add a printscreen to the PR

- Subscribe form successful from FAS results
![ezgif-3-a3f35a48ab1c](https://user-images.githubusercontent.com/869769/61638679-d24ce180-ac91-11e9-949e-f3d50737cd50.gif)

- Subscribe form sucessful after some errors
![ezgif-3-2c9751dc136e](https://user-images.githubusercontent.com/869769/61638689-d678ff00-ac91-11e9-9aa1-1dc37e23a4c1.gif)
